### PR TITLE
Mac safe modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ vagrant up
 ### Cluster Topology
 
 This will result in a 3-node chef-backend cluster, and a single front-end
-node.
+node. They are provisioned in the order listed below.
 
-* be1, 192.168.33.215
-* be2, 192.168.33.216
-* be3, 192.168.33.217
-* fe1, 192.168.33.218
+* be1, 192.168.56.215
+* be2, 192.168.56.216
+* be3, 192.168.56.217
+* fe1, 192.168.56.218
 
 ### Administering the chef-backend cluster
 The chef-backend cluster is administered with the `chef-backend-ctl` command. See the built-in help for details.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,25 +11,25 @@ Vagrant.configure(2) do |config|
 
   config.vm.define :be1 do |be1|
     be1.vm.hostname = 'be1'
-    be1.vm.network :private_network, ip: '192.168.33.215'
+    be1.vm.network :private_network, ip: '192.168.56.215'
     be1.vm.provision :shell, path: "scripts/provision_be_leader.sh"
   end
 
   config.vm.define :be2 do |be2|
     be2.vm.hostname = 'be2'
-    be2.vm.network :private_network, ip: '192.168.33.216'
+    be2.vm.network :private_network, ip: '192.168.56.216'
     be2.vm.provision :shell, path: "scripts/provision_be_follower.sh"
   end
 
   config.vm.define :be3 do |be3|
     be3.vm.hostname = 'be3'
-    be3.vm.network :private_network, ip: '192.168.33.217'
+    be3.vm.network :private_network, ip: '192.168.56.217'
     be3.vm.provision :shell, path: "scripts/provision_be_follower.sh"
   end
 
   config.vm.define :fe1 do |fe1|
     fe1.vm.hostname = 'fe1.chef-demo.com'
-    fe1.vm.network :private_network, ip: '192.168.33.218'
+    fe1.vm.network :private_network, ip: '192.168.56.218'
     fe1.vm.provision :shell, path: "scripts/provision_fe1.sh"
     fe1.vm.provider "virtualbox" do |vb|
       vb.memory = '1500'

--- a/scripts/provision_be_follower.sh
+++ b/scripts/provision_be_follower.sh
@@ -8,4 +8,4 @@ ipaddr=$(ifconfig enp0s8 | awk '/inet addr/{print substr($2,6)}')
 dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_2.0.30*.deb
 
 # Join the cluster
-chef-backend-ctl join-cluster 192.168.33.215 -p $ipaddr -s /vagrant/chef-backend-secrets.json --accept-license --yes
+chef-backend-ctl join-cluster 192.168.56.215 -p $ipaddr -s /vagrant/chef-backend-secrets.json --accept-license --yes

--- a/scripts/provision_be_follower.sh
+++ b/scripts/provision_be_follower.sh
@@ -7,5 +7,13 @@ ipaddr=$(ifconfig eth1 | awk '/inet addr/{print substr($2,6)}')
 # Install the cluster package
 dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb
 
+#Modify embedded cookbooks to change ElasticSearch jvm.options
+esjvmopts="/opt/chef-backend/embedded/cookbooks/chef-backend/templates/default/es_jvm.opts.erb"
+cat >> $esjvmopts <<EOF 
+-XX:+UnlockExperimentalVMOptions
+-XX:+UseZGC
+EOF
+sed -i '/ConcMark/d;/CMS/d' $esjvmopts
+
 # Join the cluster
 chef-backend-ctl join-cluster 192.168.56.215 -p $ipaddr -s /vagrant/chef-backend-secrets.json --accept-license --yes

--- a/scripts/provision_be_follower.sh
+++ b/scripts/provision_be_follower.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Get IP address of eth1 or enp0s8 because this is a Vagrant box
-#ipaddr=$(ifconfig eth1 | awk '/inet addr/{print substr($2,6)}')
-ipaddr=$(ifconfig enp0s8 | awk '/inet addr/{print substr($2,6)}')
+ipaddr=$(ifconfig eth1 | awk '/inet addr/{print substr($2,6)}')
+#ipaddr=$(ifconfig enp0s8 | awk '/inet addr/{print substr($2,6)}')
 
 # Install the cluster package
 dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb

--- a/scripts/provision_be_follower.sh
+++ b/scripts/provision_be_follower.sh
@@ -5,7 +5,7 @@
 ipaddr=$(ifconfig enp0s8 | awk '/inet addr/{print substr($2,6)}')
 
 # Install the cluster package
-dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_2.0.30*.deb
+dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb
 
 # Join the cluster
 chef-backend-ctl join-cluster 192.168.56.215 -p $ipaddr -s /vagrant/chef-backend-secrets.json --accept-license --yes

--- a/scripts/provision_be_leader.sh
+++ b/scripts/provision_be_leader.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Get IP address of eth1 or enp0s8 because this is a Vagrant box
-#ipaddr=$(ifconfig eth1 | awk '/inet addr/{print substr($2,6)}')
-ipaddr=$(ifconfig enp0s8 | awk '/inet addr/{print substr($2,6)}')
+ipaddr=$(ifconfig eth1 | awk '/inet addr/{print substr($2,6)}')
+#ipaddr=$(ifconfig enp0s8 | awk '/inet addr/{print substr($2,6)}')
 
 # Install the cluster package
 dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb

--- a/scripts/provision_be_leader.sh
+++ b/scripts/provision_be_leader.sh
@@ -11,8 +11,8 @@ dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb
 echo "publish_address '$ipaddr'" >> /etc/chef-backend/chef-backend.rb
 
 #Modify embedded cookbooks to change ElasticSearch jvm.options
-esjvmopts = "/opt/chef-backend/embedded/cookbooks/chef-backend/templates/default/es_jvm.opts.erb"
-cat >> $esjvmopts <<EOF 
+esjvmopts="/opt/chef-backend/embedded/cookbooks/chef-backend/templates/default/es_jvm.opts.erb"
+cat >> $esjvmopts <<EOF
 -XX:+UnlockExperimentalVMOptions
 -XX:+UseZGC
 EOF

--- a/scripts/provision_be_leader.sh
+++ b/scripts/provision_be_leader.sh
@@ -10,6 +10,14 @@ dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb
 # Create cluster configuration file
 echo "publish_address '$ipaddr'" >> /etc/chef-backend/chef-backend.rb
 
+#Modify embedded cookbooks to change ElasticSearch jvm.options
+esjvmopts = "/opt/chef-backend/embedded/cookbooks/chef-backend/templates/default/es_jvm.opts.erb"
+cat >> $esjvmopts <<EOF 
+-XX:+UnlockExperimentalVMOptions
+-XX:+UseZGC
+EOF
+sed -i '/ConcMark/d;/CMS/d' $esjvmopts
+
 # Initialize the cluster
 chef-backend-ctl create-cluster --accept-license --yes
 

--- a/scripts/provision_be_leader.sh
+++ b/scripts/provision_be_leader.sh
@@ -5,7 +5,7 @@
 ipaddr=$(ifconfig enp0s8 | awk '/inet addr/{print substr($2,6)}')
 
 # Install the cluster package
-dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_2.0.30*.deb
+dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb
 
 # Create cluster configuration file
 echo "publish_address '$ipaddr'" >> /etc/chef-backend/chef-backend.rb

--- a/scripts/provision_fe1.sh
+++ b/scripts/provision_fe1.sh
@@ -10,6 +10,9 @@ mkdir -p /etc/opscode
 [[ -s /etc/opscode/chef-server.rb ]] || \
 cp /vagrant/chef-server.rb.fe1 /etc/opscode/chef-server.rb
 
+#Ensure all backend IPs are included in config. As server config is generated before followers are joined, we need to ensure all IPs are listed.
+sed 's/"192.168.56.215"/"192.168.56.215", "192.168.56.217", "192.168.56.216"/g' /etc/opscode/chef-server.rb
+
 # Attach the chef server to the existing backend-cluster
 [[ -f /etc/opscode/private-chef-secrets.json ]] || \
 chef-server-ctl reconfigure --chef-license=accept

--- a/scripts/provision_fe1.sh
+++ b/scripts/provision_fe1.sh
@@ -11,7 +11,7 @@ mkdir -p /etc/opscode
 cp /vagrant/chef-server.rb.fe1 /etc/opscode/chef-server.rb
 
 #Ensure all backend IPs are included in config. As server config is generated before followers are joined, we need to ensure all IPs are listed.
-sed 's/"192.168.56.215"/"192.168.56.215", "192.168.56.217", "192.168.56.216"/g' /etc/opscode/chef-server.rb
+sed -i 's/"192.168.56.215"/"192.168.56.215", "192.168.56.217", "192.168.56.216"/g' /etc/opscode/chef-server.rb
 
 # Attach the chef server to the existing backend-cluster
 [[ -f /etc/opscode/private-chef-secrets.json ]] || \

--- a/scripts/provision_fe1.sh
+++ b/scripts/provision_fe1.sh
@@ -12,4 +12,4 @@ cp /vagrant/chef-server.rb.fe1 /etc/opscode/chef-server.rb
 
 # Attach the chef server to the existing backend-cluster
 [[ -f /etc/opscode/private-chef-secrets.json ]] || \
-chef-server-ctl reconfigure
+chef-server-ctl reconfigure --chef-license=accept


### PR DESCRIPTION
Changed enough of the scripts and vagrantfile that you can clone this repository, pop the .deb files for chef-server and chef-backend in, and vagrant up and you will have a successfully configured Chef-Backend cluster after 10~ minutes.
Solved a bug with 3.1.1 Backend's Elasticsearch that causes 3.1.1 to be DOA. See commit https://github.com/sean-horn/chef-backend-demo/commit/68d49d2e9c490e2364675388498634ac8c68b47c