### PR TITLE
Change es garb clctr

### DIFF
--- a/scripts/provision_be_follower.sh
+++ b/scripts/provision_be_follower.sh
@@ -9,11 +9,8 @@ dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb
 
 #Modify embedded cookbooks to change ElasticSearch jvm.options
 esjvmopts="/opt/chef-backend/embedded/cookbooks/chef-backend/templates/default/es_jvm.opts.erb"
-cat >> $esjvmopts <<EOF 
--XX:+UnlockExperimentalVMOptions
--XX:+UseZGC
-EOF
-sed -i '/ConcMark/d;/CMS/d' $esjvmopts
+sed -i '/-XX:-UseConcMarkSweepGC/d' $esjvmopts
+ed '/-XX:-UseCMSInitiatingOccupancyOnly/d' $esjvmopts
 
 # Join the cluster
 chef-backend-ctl join-cluster 192.168.56.215 -p $ipaddr -s /vagrant/chef-backend-secrets.json --accept-license --yes

--- a/scripts/provision_be_follower.sh
+++ b/scripts/provision_be_follower.sh
@@ -10,7 +10,7 @@ dpkg -s chef-backend &> /dev/null || dpkg -i /vagrant/chef-backend_*.deb
 #Modify embedded cookbooks to change ElasticSearch jvm.options
 esjvmopts="/opt/chef-backend/embedded/cookbooks/chef-backend/templates/default/es_jvm.opts.erb"
 sed -i '/-XX:-UseConcMarkSweepGC/d' $esjvmopts
-ed '/-XX:-UseCMSInitiatingOccupancyOnly/d' $esjvmopts
+sed -i '/-XX:-UseCMSInitiatingOccupancyOnly/d' $esjvmopts
 
 # Join the cluster
 chef-backend-ctl join-cluster 192.168.56.215 -p $ipaddr -s /vagrant/chef-backend-secrets.json --accept-license --yes

--- a/scripts/provision_be_leader.sh
+++ b/scripts/provision_be_leader.sh
@@ -12,11 +12,8 @@ echo "publish_address '$ipaddr'" >> /etc/chef-backend/chef-backend.rb
 
 #Modify embedded cookbooks to change ElasticSearch jvm.options
 esjvmopts="/opt/chef-backend/embedded/cookbooks/chef-backend/templates/default/es_jvm.opts.erb"
-cat >> $esjvmopts <<EOF
--XX:+UnlockExperimentalVMOptions
--XX:+UseZGC
-EOF
-sed -i '/ConcMark/d;/CMS/d' $esjvmopts
+sed -i '/-XX:-UseConcMarkSweepGC/d' $esjvmopts
+ed '/-XX:-UseCMSInitiatingOccupancyOnly/d' $esjvmopts
 
 # Initialize the cluster
 chef-backend-ctl create-cluster --accept-license --yes

--- a/scripts/provision_be_leader.sh
+++ b/scripts/provision_be_leader.sh
@@ -13,7 +13,7 @@ echo "publish_address '$ipaddr'" >> /etc/chef-backend/chef-backend.rb
 #Modify embedded cookbooks to change ElasticSearch jvm.options
 esjvmopts="/opt/chef-backend/embedded/cookbooks/chef-backend/templates/default/es_jvm.opts.erb"
 sed -i '/-XX:-UseConcMarkSweepGC/d' $esjvmopts
-ed '/-XX:-UseCMSInitiatingOccupancyOnly/d' $esjvmopts
+sed -i '/-XX:-UseCMSInitiatingOccupancyOnly/d' $esjvmopts
 
 # Initialize the cluster
 chef-backend-ctl create-cluster --accept-license --yes


### PR DESCRIPTION
Found in investigation that did not need to move to a different GC - as long it isn't Serial GC.

Instead, just need to remove the `-CMS GC` lines that are found in `jvm.options` just after the `+CMS GC` ones. I don't understand why these are there. Seems like a typo. To reflect this change i have made in this repo, I have raised a defect and Jira ticket for the Chef Backend Engineering team to look at. 